### PR TITLE
feat: track downloaded post IDs to avoid duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,7 @@ testing_folder
 
 # config
 user_config.json
+downloaded_ids.json
 reddit_post_downloader.code-workspace
 
 .DS_Store


### PR DESCRIPTION
## Summary
- improve download logs to show when posts are downloaded vs skipped as duplicates
- persist post IDs only after successful downloads
- display download status with title and author in progress output
- avoid saving post ID when self post write fails

## Testing
- `npm test` (fails: Error: no test specified)
- `node index.js` (fails: prompts require user input)


------
https://chatgpt.com/codex/tasks/task_e_68b45de818088330936b0de8a145da48